### PR TITLE
INT-380 Automate OS extension release: direct S3 upload + auto-approve release PRs

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,44 @@
+name: Auto-approve Release PRs
+
+on:
+  pull_request:
+    types: ['opened', 'reopened', 'edited', 'synchronize']
+    branches:
+      - master
+
+concurrency:
+  group: auto-approve-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  auto-approve:
+    name: Evaluate auto-approve eligibility
+    runs-on: ubuntu-latest
+    # Fork PRs do not receive secrets; the status job treats "skipped" as pass.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - uses: hivemq/hivemq-auto-approve-action@31ce48e4201f5bbfa39abdc246a352a059d8b2c6 # v1
+        with:
+          allowed-team: hivemq-team-pd
+          allowed-changes: |
+            - path: '^gradle\.properties$'
+              lines: '^version=[0-9]+\.[0-9]+\.[0-9]+$'
+          github-token: ${{ secrets.JENKINS_GITHUB_TOKEN }}
+          reviewer-login: ${{ secrets.JENKINS_GITHUB_USERNAME }}
+
+  status:
+    name: Auto-approve Release PRs
+    needs: [auto-approve]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify auto-approve job result
+        run: |
+          result="${{ needs.auto-approve.result }}"
+          echo "auto-approve job result: $result"
+          if [ "$result" = "success" ] || [ "$result" = "skipped" ]; then
+            exit 0
+          fi
+          exit 1

--- a/.github/workflows/releaseExtension.yml
+++ b/.github/workflows/releaseExtension.yml
@@ -36,3 +36,10 @@ jobs:
         run: gh release upload ${{ github.event.release.tag_name }} ./build/hivemq-extension/hivemq-aws-cloudwatch-extension-${{ github.event.release.name }}.zip.sha256
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Deploy to S3 releases bucket
+        run: |
+          aws s3 cp ./build/hivemq-extension/hivemq-aws-cloudwatch-extension-${{ github.event.release.name }}.zip s3://${{ secrets.RELEASES_S3_BUCKET }}/extensions/ --region ${{ secrets.RELEASES_S3_REGION }}
+          aws s3 cp ./build/hivemq-extension/hivemq-aws-cloudwatch-extension-${{ github.event.release.name }}.zip.sha256 s3://${{ secrets.RELEASES_S3_BUCKET }}/extensions/ --region ${{ secrets.RELEASES_S3_REGION }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.RELEASES_S3_AWS_TOKEN_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.RELEASES_S3_AWS_TOKEN_SECRET_KEY }}


### PR DESCRIPTION
## Summary

Two release-automation changes for OS extensions:

1. **Direct S3 upload** — `releaseExtension.yml` uploads the ZIP + SHA256 to `s3://releases.hivemq.com/extensions/` on `release: published`, using org-level `RELEASES_S3_*` secrets. Bucket, region, and AWS credentials are not exposed in the repo.
2. **Auto-approve release PRs** — `auto-approve.yml` approves version-bump release PRs opened by `hivemq-team-pd` members, gated to `gradle.properties` version-line changes only (azure-cluster-discovery also allows the ARM template `defaultValue` version line). Replaces the disable/enable branch-protection dance.

### Prerequisites for auto-approve to work

- Org secrets `JENKINS_GITHUB_TOKEN` + `JENKINS_GITHUB_USERNAME` must be scoped to this repo.
- Branch protection must require the `Auto-approve Release PRs` status check and the Jenkins bot approval.

Part of INT-380.
